### PR TITLE
ffmpeg/build.sh: disable libvpx asm w/msan or centipede

### DIFF
--- a/projects/ffmpeg/build.sh
+++ b/projects/ffmpeg/build.sh
@@ -115,7 +115,9 @@ make -j$(nproc) all
 make install
 
 cd $SRC/libvpx
-if [[ "$ARCHITECTURE" == i386 ]]; then
+if [[ "$SANITIZER" == "memory" ]] || [[ "$FUZZING_ENGINE" == "centipede" ]]; then
+      TARGET="--target=generic-gnu"
+elif [[ "$ARCHITECTURE" == i386 ]]; then
       TARGET="--target=x86-linux-gcc"
 else
       TARGET=""


### PR DESCRIPTION
Avoids false positives as the assembly code is not instrumented.

Bug: https://crbug.com/oss-fuzz/70943
Bug: https://crbug.com/oss-fuzz/70950
Bug: https://crbug.com/oss-fuzz/71085
Bug: https://crbug.com/oss-fuzz/71093
